### PR TITLE
Update readme for clarity, change go.py to respect locale setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,6 @@ source bin/activate
 pip install -r requirements.txt
 ```
 
-## :dvd: Database
-
-create the database (to execute only once)
-```bash
-python models.py
-```
-
 ##  :wrench: Settings
 ```bash
 mv env.sample .env
@@ -57,6 +50,13 @@ REDDIT_CLIENT_SECRET= # see below explanation
 REDDIT_PASSWORD=   # put your reddit password
 REDDIT_USERAGENT=Yeoboseyo/1.0   # whatever :P
 REDDIT_USERNAME=  #put your reddit login
+```
+
+## :dvd: Database
+
+create the database (to execute only once)
+```bash
+python models.py
 ```
 
 ##  :shell: Mastodon Service
@@ -87,7 +87,8 @@ Use those info to fill the `.env` file
 start the application
 ```bash
 cd yeoboseyo
-python app.py &여보세요 !
+python app.py &
+여보세요 !
 INFO: Started server process [13588]
 INFO: Waiting for application startup.
 INFO: Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
@@ -144,7 +145,7 @@ Publication on Mastodon
 ### get the list
 get the list of your feeds to check which one provided articles or not
 ```bash
-python run.py report
+python run.py -a report
 
 여보세요 ! Report
 ID    Name                           Notebook                       Mastodon Status  Triggered

--- a/yeoboseyo/go.py
+++ b/yeoboseyo/go.py
@@ -102,8 +102,9 @@ async def go():
 
             # retrieve the data
             feeds = await rss.get_data(**{'url_to_parse': trigger.rss_url, 'bypass_bozo': config('BYPASS_BOZO')})
-            now = arrow.utcnow().format('YYYY-MM-DDTHH:mm:ssZZ')
+            now = arrow.utcnow().to(config('TIME_ZONE')).format('YYYY-MM-DDTHH:mm:ssZZ')
             date_triggered = arrow.get(trigger.date_triggered).format('YYYY-MM-DDTHH:mm:ssZZ')
+
             read_entries = 0
             created_entries = 0
             for entry in feeds.entries:
@@ -111,7 +112,7 @@ async def go():
                 # so will have the "now" date as default
                 published = get_published(entry)
                 if published:
-                    published = arrow.get(published).format('YYYY-MM-DDTHH:mm:ssZZ')
+                    published = arrow.get(published).to(config('TIME_ZONE')).format('YYYY-MM-DDTHH:mm:ssZZ')
                 # last triggered execution
                 if published is not None and now >= published >= date_triggered:
                     read_entries += 1


### PR DESCRIPTION
I moved the database initialization below settings creating in the readme, because the settings creation needs to take place first. 
I also fixed a little bit of formatting in the readme.

I had an issue when pulling rss where some of the dates came in utc and some in local time. I edited go so that all the times should now be local (I hope I didn't miss any).