### PR TITLE
Feature/joplin nested folder

### DIFF
--- a/yeoboseyo/services/joplin.py
+++ b/yeoboseyo/services/joplin.py
@@ -66,16 +66,15 @@ class Joplin(Service):
         # build the json data
         folders = await self.get_folders()
         if folders:
-            notebook_id = 0
-            for folder in folders:
-                if folder.get('title') == trigger.joplin_folder:
-                    notebook_id = folder.get('id')
-            if notebook_id == 0:
+            def search_folders_recursively(folders, search_title):
                 for folder in folders:
-                    if 'children' in folder:
-                        for child in folder.get('children'):
-                            if child.get('title') == trigger.joplin_folder:
-                                notebook_id = child.get('id')
+                    if folder.get('title') == search_title:
+                        return folder.get('id')
+                    elif 'children' in folder:
+                        result = search_folders_recursively(folder.get('children'), search_title)
+                        if result is not None:
+                            return result
+            notebook_id = search_folders_recursively(folders, trigger.joplin_folder) or 0
             data = {'title': entry.title,
                     'body': content,
                     'parent_id': notebook_id,

--- a/yeoboseyo/services/joplin.py
+++ b/yeoboseyo/services/joplin.py
@@ -75,10 +75,14 @@ class Joplin(Service):
                         if result is not None:
                             return result
             notebook_id = search_folders_recursively(folders, trigger.joplin_folder) or 0
+            try:
+                author = entry.author
+            except AttributeError:
+                author = '' # Not all feeds always provide an author
             data = {'title': entry.title,
                     'body': content,
                     'parent_id': notebook_id,
-                    'author': entry.author,
+                    'author': author,
                     'source_url': entry.link}
             url = f'{self.joplin_url}:{self.joplin_port}/notes'
             logger.debug(url)

--- a/yeoboseyo/services/localstorage.py
+++ b/yeoboseyo/services/localstorage.py
@@ -42,10 +42,14 @@ class LocalStorage(Service):
         # get the content of the Feeds
         content = await self.create_body_content(trigger.description, entry)
         p = Path(self.local_storage + '/' + trigger.localstorage)
+        try:
+            author = entry.author
+        except AttributeError:
+            author = '' # Not all feeds always provide an author
         if p.is_dir():
             data = {'title': entry.title,
                     'body': content,
-                    'author': entry.author,
+                    'author': author,
                     'source_url': entry.link,
                     'localstorage': trigger.localstorage}
             logger.debug(data)


### PR DESCRIPTION
Folders in Joplin can be nested more than 1 layer deep.
Now yeoboseyo is able to find all of them with a depth-first search - that is the same order in which they are displayed inside joplin.

Some RSS Feeds miss the "author" field, for example reddit-posts where the author deleted their account.
As a replacement I simply put in an empty string, though something else like "Unknown" could be possible.